### PR TITLE
Remove invalid domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ In addition to the methods above for removing individual components, you can com
 
 #### Special Acknowledgements to:
 
-- <a href="http://www.spellholdstudios.net/">Spellhold Studios</a> team for hosting the mod (<a href="http://www.shsforums.net">Forums</a>).
+- <a href="https://www.shsforums.net/">Spellhold Studios</a> team for hosting the mod.
 - <a href="https://www.gibberlings3.net/">Gibberlings3</a> team for hosting the mod (<a href="https://www.gibberlings3.net/forums">Forums</a>).
 - The creators of the Baldur's Gate series: <a href="http://www.bioware.com/">Bioware</a> and <a href="http://www.obsidian.net/">Black Isle Studios</a>.
 - For the great support and help: **Galactygon**, **Jastey**, **Salk**, **Sam**, **TotoR**, **ALIENQuake**, **skellytz** ... without the constant feedback, everything would not have been so possible<br> and many more, which I can't look up now, because the SHSForum is down. Should it work again, I will add all the others here, or they should contact me :)

--- a/bggo/readme/README.html
+++ b/bggo/readme/README.html
@@ -19,7 +19,7 @@
                 Author: Yovaneth, Weigo • <acronym title="Weimer Dialogue Utility">WeiDU</acronym> coding: <a href="#credits">Multiple</a>
             </p>
             <p class="about">
-                <a href="http://www.spellholdstudios.net/ie/baldurs">Mod Website</a> • <a href="http://www.shsforums.net/forum/641-bg-graphics-overhaul/">Mod Forum</a> • <a href="https://www.gibberlings3.net/forums/topic/36946-baldurs-gate-graphical-overhaul-bggo-for-eet-bgt-tutu-bgee/">Mod Forum Alternativ</a> •
+                <a href="https://mods.shsforums.net/">Mod Website</a> • <a href="http://www.shsforums.net/forum/641-bg-graphics-overhaul/">Mod Forum</a> • <a href="https://www.gibberlings3.net/forums/topic/36946-baldurs-gate-graphical-overhaul-bggo-for-eet-bgt-tutu-bgee/">Mod Forum Alternativ</a> •
                 <a href="http://www.shsforums.net/files/category/119-bg-graphics-overhaul/">Download</a> •
                 <a href="https://github.com/Spellhold-Studios/Baldurs-Gate-Graphical-Overhaul">GitHub</a> • <span id="latestVersion">
             </span></p>
@@ -397,7 +397,7 @@ mod-specific issues, please report the problem in the mod's <a href="http://www.
                 <h5>Special Acknowledgements to:</h5>
 
                 <ul class="version-list c1">
-                    <li><a href="http://www.spellholdstudios.net/">Spellhold Studios</a> team for hosting the mod (<a href="http://www.shsforums.net/">Forums</a>).</li>
+                    <li><a href="https://www.shsforums.net/">Spellhold Studios</a> team for hosting the mod.</li>
                     <li>For the great support and help: <strong>Galactygon</strong>, <strong>Jastey</strong>, <strong>Salk</strong>, <strong>Sam</strong>, <strong>TotoR</strong> ... without the constant feedback, everything would not have been so possible<br> and many more, which I can&#39;t look up now, because the SHSForum is down. Should it work again, I will add all the others here, or they should contact me :)</li>
 					<li>Everyone else from <a href="https://www.gibberlings3.net/forums/">The Gibberlings Three</a>, <a href="http://www.shsforums.net/">Spellhold Studios</a> forums, and the other Infinity Engine
                         gaming and modding communities who offered their help and support.</li>


### PR DESCRIPTION
The spellholdstudios.net domain no longer belongs to SHS.